### PR TITLE
(GH-129) (vscode-tslint) Update to new ms-vscode.vscode-typescript-tslint-plugin extension

### DIFF
--- a/manual/vscode-tslint/tools/ChocolateyInstall.ps1
+++ b/manual/vscode-tslint/tools/ChocolateyInstall.ps1
@@ -1,2 +1,10 @@
 Update-SessionEnvironment
-code --install-extension eg2.tslint
+
+$deprecatedVersionExists = code --list-extensions | Where-Object { $_ -eq "eg2.tslint" }
+if ($deprecatedVersionExists)
+{
+    Write-Warning "The deprecated vscode-tslint extension is already installed. Uninstalling it to avoid linting files twice."
+    code --uninstall-extension eg2.tslint
+}
+
+code --install-extension ms-vscode.vscode-typescript-tslint-plugin

--- a/manual/vscode-tslint/tools/chocolateyUninstall.ps1
+++ b/manual/vscode-tslint/tools/chocolateyUninstall.ps1
@@ -1,2 +1,2 @@
 Update-SessionEnvironment
-code --uninstall-extension eg2.tslint
+code --uninstall-extension ms-vscode.vscode-typescript-tslint-plugin

--- a/manual/vscode-tslint/vscode-tslint.nuspec
+++ b/manual/vscode-tslint/vscode-tslint.nuspec
@@ -3,20 +3,20 @@
   <metadata>
     <id>vscode-tslint</id>
     <title>Visual Studio Code TSLint Extension</title>
-    <version>1.0.0.20181011</version>
+    <version>1.0.0.20190730</version>
     <authors>egamma</authors>
     <owners>Pascal Berger</owners>
-    <projectUrl>https://marketplace.visualstudio.com/items?itemName=eg2.tslint</projectUrl>
-    <projectSourceUrl>https://github.com/Microsoft/vscode-tslint</projectSourceUrl>
+    <projectUrl>https://marketplace.visualstudio.com/items?itemName=ms-vscode.vscode-typescript-tslint-plugin</projectUrl>
+    <projectSourceUrl>https://github.com/Microsoft/vscode-typescript-tslint-plugin</projectSourceUrl>
     <packageSourceUrl>https://github.com/pascalberger/chocolatey-packages/tree/master/manual/vscode-tslint</packageSourceUrl>
     <iconUrl>https://cdn.jsdelivr.net/gh/pascalberger/chocolatey-packages@3ed1399ef70d091e9e7cc2129c694ba1abbb37cf/icons/vscode-tslint.png</iconUrl>
-    <licenseUrl>https://marketplace.visualstudio.com/items/eg2.tslint/license</licenseUrl>
-    <docsUrl>https://github.com/Microsoft/vscode-tslint/blob/master/README.md</docsUrl>
+    <licenseUrl>https://marketplace.visualstudio.com/items/ms-vscode.vscode-typescript-tslint-plugin/license</licenseUrl>
+    <docsUrl>https://github.com/microsoft/vscode-typescript-tslint-plugin/blob/master/README.md</docsUrl>
     <bugTrackerUrl>https://github.com/Microsoft/vscode-tslint/issues</bugTrackerUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <summary>Visual Studio Code TSLint Extension</summary>
     <description>
-Integrates the [tslint](https://github.com/palantir/tslint) linter for the TypeScript language into VS Code.
+Adds [tslint](https://github.com/palantir/tslint) to VS Code using the [TypeScript TSLint language service plugin](https://github.com/Microsoft/typescript-tslint-plugin).
 
 Please refer to the tslint [documentation](https://github.com/palantir/tslint) for how to configure the linting rules.
 
@@ -26,7 +26,7 @@ Please refer to the tslint [documentation](https://github.com/palantir/tslint) f
   The version of the Chocolatey package reflects not the version of the extension.
     </description>
     <tags>microsoft visualstudiocode vscode extension linting typescript tslint</tags>
-    <releaseNotes>https://marketplace.visualstudio.com/items/eg2.tslint/changelog</releaseNotes>
+    <releaseNotes>https://marketplace.visualstudio.com/items/ms-vscode.vscode-typescript-tslint-plugin/changelog</releaseNotes>
     <dependencies>
       <dependency id="vscode" version="1.2.0" />
     </dependencies>


### PR DESCRIPTION
Change from the deprecated eg2.tslint extension to the new ms-vscode.vscode-typescript-tslint-plugin extension

Fixes #129 