### PR TITLE
(vscode-powershell) Embed VSIX

### DIFF
--- a/automatic/vscode-powershell/README.md
+++ b/automatic/vscode-powershell/README.md
@@ -1,8 +1,7 @@
 # <img src="https://cdn.jsdelivr.net/gh/pascalberger/chocolatey-packages@2f8f7a947a9a481d811b39f7e73f3574bf9ea11a/icons/vscode-powershell.png" width="48" height="48"/> [vscode-powershell](https://chocolatey.org/packages/vscode-powershell)
 
 This extension provides rich PowerShell language support for [Visual Studio Code](https://github.com/Microsoft/vscode).
-Now you can write and debug PowerShell scripts using the excellent IDE-like interface
-that Visual Studio Code provides.
+Now you can write and debug PowerShell scripts using the excellent IDE-like interface that Visual Studio Code provides.
 
 ## Features
 
@@ -14,10 +13,11 @@ that Visual Studio Code provides.
 * Find References of cmdlets and variables
 * Document and workspace symbol discovery
 * Run selected selection of PowerShell code using `F8`
-* Launch online help for the symbol under the cursor using `Ctrl+F1`
+* Launch online help for the symbol under the cursor using `Ctrl`+`F1`
 * Local script debugging and basic interactive console support!
 
 ## Notes
 
-* The package always installs the latest version of the extension.
-  The version of the Chocolatey package reflects not the version of the extension.
+* This package requires Visual Studio Code 1.2.0 or newer.
+  You can install either the [vscode](https://chocolatey.org/packages/vscode) or [vscode-insiders](https://chocolatey.org/packages/vscode-insiders) package.
+* The extension will be installed in any edition of Visual Studio Code which can be found.

--- a/automatic/vscode-powershell/legal/LICENSE.txt
+++ b/automatic/vscode-powershell/legal/LICENSE.txt
@@ -1,0 +1,14 @@
+PowerShell for Visual Studio Code
+
+Copyright (c) Microsoft Corporation
+
+All rights reserved.
+
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the ""Software""), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+

--- a/automatic/vscode-powershell/legal/VERIFICATION.txt
+++ b/automatic/vscode-powershell/legal/VERIFICATION.txt
@@ -1,0 +1,15 @@
+VERIFICATION
+Verification is intended to assist the Chocolatey moderators and community
+in verifying that this package's contents are trustworthy.
+
+The extension has been downloaded from GitHub and can be verified like this:
+
+1. Download the following extension: <foo>
+2. You can use one of the following methods to obtain the checksum
+  - Use powershell function 'Get-Filehash'
+  - Use chocolatey utility 'checksum.exe'
+
+  checksum type: foo 
+  checksum: foo
+
+File 'LICENSE.txt' is obtained from <https://github.com/PowerShell/vscode-powershell/blob/adca2cdd4aad34cd31ec550b4e5910686d500082/LICENSE.txt>

--- a/automatic/vscode-powershell/tools/chocolateyInstall.ps1
+++ b/automatic/vscode-powershell/tools/chocolateyInstall.ps1
@@ -1,0 +1,11 @@
+$ErrorActionPreference = 'Stop'
+
+$toolsDir = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
+
+$extensionName = "PowerShell-"
+$extensionVersion = "1.0.0"
+$extensionId = "$toolsDir\$extensionName$extensionVersion.vsix"
+
+Update-SessionEnvironment
+
+Install-VsCodeExtension -extensionId $extensionId

--- a/automatic/vscode-powershell/tools/chocolateyUninstall.ps1
+++ b/automatic/vscode-powershell/tools/chocolateyUninstall.ps1
@@ -1,0 +1,5 @@
+$ErrorActionPreference = 'Stop'
+
+Update-SessionEnvironment
+
+Uninstall-AzureDataStudioExtension -extensionId "ms-vscode.PowerShell"

--- a/automatic/vscode-powershell/update.ps1
+++ b/automatic/vscode-powershell/update.ps1
@@ -1,0 +1,36 @@
+import-module au
+
+$domain = 'https://github.com'
+$releases = "$domain/PowerShell/vscode-powershell/releases/latest"
+
+function global:au_BeforeUpdate { Get-RemoteFiles -Purge -NoSuffix }
+function global:au_SearchReplace {
+    @{
+        ".\legal\verification.txt" = @{
+            "(?i)(Download the following extension:.+)\<.*\>" = "`${1}<$($Latest.URL32)>"
+            "(?i)(checksum type:\s+).*" = "`${1}$($Latest.ChecksumType32)"
+            "(?i)(checksum:\s+).*" = "`${1}$($Latest.Checksum32)"
+        }
+        
+        ".\tools\chocolateyInstall.ps1" = @{
+            "(extensionVersion\s*=\s*)`"([^*]+)`"" = "`$1`"$($Latest.Version)`""
+        }
+     }
+}
+
+function global:au_GetLatest {
+    $download_page = Invoke-WebRequest -Uri $releases -UseBasicParsing
+
+    #https://github.com/PowerShell/vscode-powershell/releases/download/v2019.5.0/PowerShell-2019.5.0.vsix
+    $re  = "PowerShell-.+.vsix"
+    $url = $download_page.links | Where-Object href -match $re | Select-Object -First 1 -expand href | ForEach-Object { $domain + $_ }
+    $file = $url -split '-' | Select-Object -Last 1
+    $version = [IO.Path]::GetFileNameWithoutExtension($file)
+
+    @{
+        Version = $version
+        URL32   = $url
+    }
+}
+
+update -ChecksumFor none

--- a/automatic/vscode-powershell/vscode-powershell.nuspec
+++ b/automatic/vscode-powershell/vscode-powershell.nuspec
@@ -15,10 +15,8 @@
     <bugTrackerUrl>https://github.com/PowerShell/vscode-powershell/issues</bugTrackerUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <summary>PowerShell Language Support for Visual Studio Code</summary>
-    <description>
-This extension provides rich PowerShell language support for [Visual Studio Code](https://github.com/Microsoft/vscode).
-Now you can write and debug PowerShell scripts using the excellent IDE-like interface
-that Visual Studio Code provides.
+    <description><![CDATA[This extension provides rich PowerShell language support for [Visual Studio Code](https://github.com/Microsoft/vscode).
+Now you can write and debug PowerShell scripts using the excellent IDE-like interface that Visual Studio Code provides.
 
 ## Features
 
@@ -30,21 +28,23 @@ that Visual Studio Code provides.
 * Find References of cmdlets and variables
 * Document and workspace symbol discovery
 * Run selected selection of PowerShell code using `F8`
-* Launch online help for the symbol under the cursor using `Ctrl+F1`
+* Launch online help for the symbol under the cursor using `Ctrl`+`F1`
 * Local script debugging and basic interactive console support!
 
 ## Notes
 
-* The package always installs the latest version of the extension.
-  The version of the Chocolatey package reflects not the version of the extension.
-    </description>
+* This package requires Visual Studio Code 1.2.0 or newer.
+  You can install either the [vscode](https://chocolatey.org/packages/vscode) or [vscode-insiders](https://chocolatey.org/packages/vscode-insiders) package.
+* The extension will be installed in any edition of Visual Studio Code which can be found.
+]]></description>
     <tags>microsoft visualstudiocode vscode extension powershell</tags>
     <releaseNotes>https://marketplace.visualstudio.com/items/ms-vscode.PowerShell/changelog</releaseNotes>
     <dependencies>
-      <dependency id="vscode" version="1.2.0" />
+      <dependency id="chocolatey-vscode.extension" version="1.0.0" />
     </dependencies>
   </metadata>
   <files>
     <file src="tools\**" target="tools" />
+    <file src="legal\**" target="legal" />
   </files>
 </package>

--- a/manual/vscode-powershell/tools/ChocolateyInstall.ps1
+++ b/manual/vscode-powershell/tools/ChocolateyInstall.ps1
@@ -1,2 +1,0 @@
-Update-SessionEnvironment
-code --install-extension ms-vscode.PowerShell

--- a/manual/vscode-powershell/tools/chocolateyUninstall.ps1
+++ b/manual/vscode-powershell/tools/chocolateyUninstall.ps1
@@ -1,2 +1,0 @@
-Update-SessionEnvironment
-code --uninstall-extension ms-vscode.PowerShell

--- a/manual/vscode-powershell/update.ps1
+++ b/manual/vscode-powershell/update.ps1
@@ -1,2 +1,0 @@
-. "$PSScriptRoot\..\..\scripts\Set-DescriptionFromReadme.ps1"
-Set-DescriptionFromReadme -SkipFirst 1


### PR DESCRIPTION
Embed VSIX for vscode-powershell package.

Uses now also `chocolatey-vscode.extension` extension which allows to install the extension in user level or insider builds.

Fixes #115