### PR TITLE
(vscode-docker) Support different editions

### DIFF
--- a/manual/vscode-docker/README.md
+++ b/manual/vscode-docker/README.md
@@ -14,5 +14,8 @@ The Docker extension makes it easy to build, manage and deploy containerized app
 
 ## Notes
 
+* This package requires Visual Studio Code 1.2.0 or newer.
+  You can install either the [vscode](https://chocolatey.org/packages/vscode) or [vscode-insiders](https://chocolatey.org/packages/vscode-insiders) package.
+* The extension will be installed in any edition of Visual Studio Code which can be found.
 * The package always installs the latest version of the extension.
-  The version of the Chocolatey package reflects not the version of the extension.
+  The version of the Chocolatey package does not reflect the version of the extension.

--- a/manual/vscode-docker/tools/ChocolateyInstall.ps1
+++ b/manual/vscode-docker/tools/ChocolateyInstall.ps1
@@ -1,2 +1,5 @@
+$ErrorActionPreference = 'Stop'
+
 Update-SessionEnvironment
-code --install-extension ms-azuretools.vscode-docker
+
+Install-VsCodeExtension "ms-azuretools.vscode-docker"

--- a/manual/vscode-docker/tools/ChocolateyUninstall.ps1
+++ b/manual/vscode-docker/tools/ChocolateyUninstall.ps1
@@ -1,2 +1,5 @@
+$ErrorActionPreference = 'Stop'
+
 Update-SessionEnvironment
-code --uninstall-extension ms-azuretools.vscode-docker
+
+Uninstall-VsCodeExtension -extensionId "ms-azuretools.vscode-docker"

--- a/manual/vscode-docker/vscode-docker.nuspec
+++ b/manual/vscode-docker/vscode-docker.nuspec
@@ -30,13 +30,16 @@ The Docker extension makes it easy to build, manage and deploy containerized app
 
 ## Notes
 
+* This package requires Visual Studio Code 1.2.0 or newer.
+  You can install either the [vscode](https://chocolatey.org/packages/vscode) or [vscode-insiders](https://chocolatey.org/packages/vscode-insiders) package.
+* The extension will be installed in any edition of Visual Studio Code which can be found.
 * The package always installs the latest version of the extension.
-  The version of the Chocolatey package reflects not the version of the extension.
+  The version of the Chocolatey package does not reflect the version of the extension.
     </description>
     <tags>microsoft visualstudiocode vscode extension docker</tags>
     <releaseNotes>https://marketplace.visualstudio.com/items/PeterJausovec.vscode-docker/changelog</releaseNotes>
     <dependencies>
-      <dependency id="vscode" version="1.2.0" />
+      <dependency id="chocolatey-vscode.extension" version="1.1.0" />
     </dependencies>
   </metadata>
   <files>


### PR DESCRIPTION
Support installing of the Visual Studio Code Docker extension into different editions of Visual Studio Code (Insider, User-Level installer)