### PR TITLE
Fix branch names

### DIFF
--- a/.github/workflows/run-command.yml
+++ b/.github/workflows/run-command.yml
@@ -2,7 +2,7 @@ name: Run Command
 
 on:
   push:
-    branches: [main]
+    branches: [master]
   workflow_dispatch: # Enable manual trigger
     inputs:
       packages:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,7 @@ name: Test
 
 on:
   pull_request:
-    branches: [main]
+    branches: [master]
 
 jobs:
   test:
@@ -54,7 +54,7 @@ jobs:
         shell: powershell
         run: |
           Set-Service wuauserv -StartupType Manual
-          git fetch origin main:refs/remotes/origin/main
+          git fetch origin master:refs/remotes/origin/master
           .\scripts\Test-RepoPackage.ps1 -CleanFiles -TakeScreenshots -artifactsDirectory ${{ env.RUNNER_TEMP }}\artifacts
         env:
           github_api_key: ${{ secrets.GITHUBREPO_API_KEY }}

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -2,7 +2,7 @@ name: Update
 
 on:
   push:
-    branches: [main]
+    branches: [master]
   workflow_dispatch: # Enable manual trigger
     inputs:
       forced_packages:


### PR DESCRIPTION
Fix name of default branch in GitHub workflows from `main` to `master`