### PR TITLE
Remove Mergify settings

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,5 +1,0 @@
-pull_request_rules:
-  - name: delete head branch after merge
-    conditions: []
-    actions:
-      delete_head_branch: {}


### PR DESCRIPTION
Remove Mergify settings since deleting of head branches after merges is now a default feature of GitHub