### PR TITLE
Fix vscode-mssql ChocolateyInstall script.

### DIFF
--- a/automatic/vscode-mssql/tools/chocolateyInstall.ps1
+++ b/automatic/vscode-mssql/tools/chocolateyInstall.ps1
@@ -5,7 +5,7 @@ $toolsDir = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
 $extensionName = "mssql-"
 $extensionVersion = "1.35.0"
 $osBitness = Get-OSArchitectureWidth
-$extensionId = "$toolsDir\$extensionName$extensionVersion-win7-x$osBitness.vsix"
+$extensionId = "$toolsDir\$extensionName$extensionVersion-win-x$osBitness.vsix"
 
 Update-SessionEnvironment
 


### PR DESCRIPTION
Fix for the issue #183

Tested by locally creating the choco package with the change (`choco pack .\1.35.0\vscode-mssql.nuspec --version 1.35.0`) and installing the package (`choco install -s . vscode-mssql`). Worked as expected.